### PR TITLE
Optimize using in-place math; small cleanups

### DIFF
--- a/src/expmv_fun.jl
+++ b/src/expmv_fun.jl
@@ -1,6 +1,6 @@
 export expmv
 
-function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = false, prnt = false)
+function expmv(t, A, b; M::Array{Float64, 2} = Array(Float64, 0, 0), prec = "double", shift = false, full_term = false, prnt = false)
                # bal = false, 
 
     #EXPMV   Matrix exponential times vector or matrix.
@@ -41,22 +41,22 @@ function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = fals
     end
     
     if isempty(M)
-        tt = 1
+        tt = 1.0
         M = select_taylor_degree(t * A, size(b, 2))
     else
         tt = t
     end
     
-    tol =   
-      if prec == "double"
-          2.0^(-53)
+    tol =
+      if prec == "half"
+          2.0^(-10)
       elseif prec == "single"
           2.0^(-24)
-      elseif prec == "half"   
-          2.0^(-10)
+      else
+          2.0^(-53)
       end
     
-    s = 1;
+    s = 1.0;
     
     if t == 0
         m = 0;
@@ -74,15 +74,13 @@ function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = fals
             cost,m = findmin(C);  # when C is one column. Happens if p_max = 2.
         end
         if cost == Inf
-            cost = 0 
+            cost = 0.0
         end
-        s = max(cost/m,1);
+        s = max(cost/m,1.0);
     end
     
-    eta = 1;
-    
     if shift 
-        eta = exp(t*mu/s)
+        eta = exp(t * mu / s)
     end
     
     f = b;
@@ -108,7 +106,9 @@ function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = fals
             end
             
         end
-        f = eta*f
+        if shift
+            f = eta*f
+        end
         b = f
     end
     

--- a/src/expmv_fun.jl
+++ b/src/expmv_fun.jl
@@ -4,12 +4,9 @@ function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = fals
                # bal = false, 
 
     #EXPMV   Matrix exponential times vector or matrix.
-    #   [F,S,M,MV,MVD] = EXPMV(t,A,B,[],PREC) computes EXPM(t*A)*B without
+    #   [F,S,M] = EXPMV(t,A,B,[],PREC) computes EXPM(t*A)*B without
     #   explicitly forming EXPM(t*A). PREC is the required accuracy, 'double',
     #   'single' or 'half', and defaults to CLASS(A).
-    #
-    #   A total of MV products with A or A^* are used, of which MVD are
-    #   for norm estimation.
     #
     #   The full syntax is
     #
@@ -48,12 +45,9 @@ function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = fals
     
     if isempty(M)
         tt = 1
-        (M,mvd,alpha,unA) = select_taylor_degree(t*A,b)
-        mv = mvd
+        (M,alpha,unA) = select_taylor_degree(t*A,b)
     else
         tt = t
-        mv = 0
-        mvd = 0
     end
     
     tol =   
@@ -104,7 +98,6 @@ function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = fals
         c1 = norm(b,Inf);
         for k = 1:m
             b = (t/(s*k))*(A*b);
-            mv = mv + 1;
             f =  f + b;
             c2 = norm(b,Inf);
             if !full_term
@@ -130,6 +123,5 @@ function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = fals
     #    f = D*f
     #end
     
-    #return (f,s,m,mv,mvd,unA)
     return f
 end

--- a/src/expmv_fun.jl
+++ b/src/expmv_fun.jl
@@ -10,9 +10,7 @@ function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = fals
     #
     #   The full syntax is
     #
-    #     [f,s,m,mv,mvd,unA] = expmv(t,A,b,M,prec,shift,bal,full_term,prnt).
-    #
-    #   unA = 1 if the alpha_p were used instead of norm(A).
+    #     f = expmv(t,A,b,M,prec,shift,bal,full_term,prnt).
     #
     #   If repeated invocation of EXPMV is required for several values of t
     #   or B, it is recommended to provide M as an external parameter as
@@ -38,14 +36,13 @@ function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = fals
     n = size(A,1)
     
     if shift
-        mu = trace(A)/n 
-        #mu = full(mu) # Much slower without the full!
+        mu = trace(A)/n
         A = A-mu*speye(n)
     end
     
     if isempty(M)
         tt = 1
-        (M,alpha,unA) = select_taylor_degree(t*A,b)
+        M = select_taylor_degree(t * A, b)
     else
         tt = t
     end

--- a/src/expmv_fun.jl
+++ b/src/expmv_fun.jl
@@ -14,7 +14,7 @@ function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = fals
     #
     #   If repeated invocation of EXPMV is required for several values of t
     #   or B, it is recommended to provide M as an external parameter as
-    #   M = SELECT_TAYLOR_DEGREE(A,m_max,p_max,prec,shift,bal,true).
+    #   M = SELECT_TAYLOR_DEGREE(A,b_columns,m_max,p_max,prec,shift,bal,true).
     #   This also allows choosing different m_max and p_max.
     
     #   Reference: A. H. Al-Mohy and N. J. Higham, Computing the action of
@@ -42,7 +42,7 @@ function expmv(t, A, b; M = [], prec = "double", shift = false, full_term = fals
     
     if isempty(M)
         tt = 1
-        M = select_taylor_degree(t * A, b)
+        M = select_taylor_degree(t * A, size(b, 2))
     else
         tt = t
     end

--- a/src/normAm.jl
+++ b/src/normAm.jl
@@ -56,15 +56,13 @@ function normAm(A,m)
             e = A'*e;
         end
         c = norm(e,Inf);
-        mv = m;
     else
         #(c,_,_,it) = normest1(@afun_power,t);
         #mv = it[2]*t*m;
         c = norm(A^m,1);
-        mv = 6*t*m;
     end
     
-    return (c,mv)
+    return c
     
 end
 

--- a/src/select_taylor_degree.jl
+++ b/src/select_taylor_degree.jl
@@ -1,5 +1,5 @@
 function select_taylor_degree(A,
-                              b;
+                              b_columns;
                               m_max = 55,
                               p_max = 8,
                               prec = "double",
@@ -48,7 +48,7 @@ function select_taylor_degree(A,
         normA = norm(A,1)
     end
     
-    if !force_estm && normA <= 4*theta[m_max]*p_max*(p_max + 3)/(m_max*size(b,2));
+    if !force_estm && normA <= 4*theta[m_max]*p_max*(p_max + 3)/(m_max*b_columns);
         c = normA;
         alpha = c*ones(p_max-1,1);
     else

--- a/src/select_taylor_degree.jl
+++ b/src/select_taylor_degree.jl
@@ -49,11 +49,9 @@ function select_taylor_degree(A,
     end
     
     if !force_estm && normA <= 4*theta[m_max]*p_max*(p_max + 3)/(m_max*size(b,2));
-        unA = 1;
         c = normA;
         alpha = c*ones(p_max-1,1);
     else
-        unA = 0;
         eta = zeros(p_max,1); 
         alpha = zeros(p_max-1,1);
         for p = 1:p_max
@@ -74,5 +72,5 @@ function select_taylor_degree(A,
         end
     end
     
-    return (M,alpha,unA)
+    return M
 end

--- a/src/select_taylor_degree.jl
+++ b/src/select_taylor_degree.jl
@@ -1,6 +1,3 @@
-#function  [M,mv,alpha,unA] = ...
-#           select_taylor_degree(A,b,m_max,p_max,prec,shift,bal,force_estm)
-
 function select_taylor_degree(A,
                               b;
                               m_max = 55,
@@ -12,10 +9,9 @@ function select_taylor_degree(A,
 
 
     #SELECT_TAYLOR_DEGREE   Select degree of Taylor approximation.
-    #   [M,MV,alpha,unA] = SELECT_TAYLOR_DEGREE(A,m_max,p_max) forms a matrix M
+    #   [M,alpha,unA] = SELECT_TAYLOR_DEGREE(A,m_max,p_max) forms a matrix M
     #   for use in determining the truncated Taylor series degree in EXPMV
     #   and EXPMV_TSPAN, based on parameters m_max and p_max.
-    #   MV is the number of matrix-vector products with A or A^* computed.
     
     #   Reference: A. H. Al-Mohy and N. J. Higham, Computing the action of
     #   the matrix exponential, with an application to exponential
@@ -48,8 +44,6 @@ function select_taylor_degree(A,
         A = A-mu*speye(n);
     end
     
-    mv = 0;
-    
     if !force_estm
         normA = norm(A,1)
     end
@@ -63,9 +57,8 @@ function select_taylor_degree(A,
         eta = zeros(p_max,1); 
         alpha = zeros(p_max-1,1);
         for p = 1:p_max
-            (c,k) = normAm(A,p+1);
+            c = normAm(A,p+1);
             c = c^(1/(p+1));
-            mv = mv + k;
             eta[p] = c;
         end
         for p = 1:p_max-1
@@ -81,6 +74,5 @@ function select_taylor_degree(A,
         end
     end
     
-    return (M,mv,alpha,unA)
-    
+    return (M,alpha,unA)
 end


### PR DESCRIPTION
I was recently using ExmpV.jl for solving a Lindblad master equation for a time-independent system of coupled harmonic oscillators, i.e. a very sparse `A` that is constant over many `exmpv` iterations. In this use case, the loop part of `expmv_fun` was definitely the bottleneck for my whole application, given that I could pre-compute the `select_taylor_degree` result.

This PR changes the code to explicitly allocate some copies of vectors before the loop and then use in-place operations to avoid excessive GC usage (according to `@time`, my program churned through something like 2 TB of GC memory in a couple of minutes). <del>It also replaces the calculation of the infinity norm by the `iamax` BLAS function.</del> All in all, this leads to several times of performance gain in my use case.

There is likely still quite a bit more to optimize here, both in terms of performance and code style. I'm new to Julia, so I'd appreciate any pointers.
